### PR TITLE
#10 - basic.proto files added types with error, void, empty

### DIFF
--- a/basic.proto
+++ b/basic.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+
+message Void {}
+
+message Null {}
+
+message Error {
+    string type = 1;
+    string code = 2;
+    string message = 3;
+}
+

--- a/cache.proto
+++ b/cache.proto
@@ -7,10 +7,10 @@ import "proudcts.proto";
 
 
 service CacheService {
-  rpc GetCache (CacheInput) returns (Cache) {};
-  rpc SetCache (CacheInput) returns (Empty) {};
-  rpc DelCache (CacheInput) returns (Empty) {};
-  rpc ResetCache (Empty) returns (Empty) {};
+  rpc Get (CacheInput) returns (Cache) {};
+  rpc Set (CacheInput) returns (Empty) {};
+  rpc Del (CacheInput) returns (Empty) {};
+  rpc Reset (Empty) returns (Empty) {};
 }
 
 message Error {

--- a/event.proto
+++ b/event.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package event;
 
-import "./basic.proto";
+import "basic.proto";
 
 service EventService {
   rpc TriggerEvent (TriggerEventInput) returns (Void) {};
@@ -34,12 +34,12 @@ enum AuthEvents {
     UserLoginEvent = 2;
 }
 enum Events {
-   oneof EventType {
+    oneof EventType {
         ProductEvents productEvent = 1;
         SocketEvents SocketEvent = 2;
         RBACEvents rbacEvent = 3;
         AuthEvents authEvent = 4;
-   }
+    }
 }
 
 message Recipiant {

--- a/event.proto
+++ b/event.proto
@@ -1,10 +1,11 @@
 syntax = "proto3";
 package event;
 
+import "./basic.proto";
 
 service EventService {
-  rpc TriggerEvent (TriggerEventInput) returns (Empty) {};
-  rpc BroadcastEvent (TriggerEventInput) returns (Empty) {};
+  rpc TriggerEvent (TriggerEventInput) returns (Void) {};
+  rpc BroadcastEvent (TriggerEventInput) returns (Void) {};
 }
 
 enum ProductEvents {
@@ -52,5 +53,3 @@ message TriggerEventInput {
     Events event = 2;
     repeated string data = 3;
 }
-
-message Empty { }

--- a/product.proto
+++ b/product.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 
 package product;
 
-import "./basic.proto";
+import "basic.proto";
 
 service ProductController {
   rpc GetProductById (ProductById) returns (Product) {}

--- a/products.proto
+++ b/products.proto
@@ -3,25 +3,26 @@ syntax = "proto3";
 
 package product;
 
+import "./basic.proto";
+
 service ProductController {
   rpc GetProductById (ProductById) returns (Product) {}
-  rpc GetProducts (voidNoParam) returns (Products);
+  rpc GetProducts (Void) returns (Products);
 }
 
 message ProductById {
   string id = 1;
 }
 
-message voidNoParam{}
 
 message Products {
   repeated Product products = 1;
 }
 
 enum PriceType {
-    TL = 1;
-    USD = 2;
-    EUR = 3;
+    TL = 0;
+    USD = 1;
+    EUR =2;
   }
 
 message Price {
@@ -43,10 +44,6 @@ message Product {
   map<string, string> specs = 10;
 }
 
-message Error {
-  string message = 1;
-  string code = 2;
-}
 
 message ProductReturnType {
   oneof response {


### PR DESCRIPTION
#10 product|event|cache proto now uses basic proto as basic types


you can use basic.proto like so
```go 

syntax = "proto3";

package product;

import "./basic.proto";

service ProductController {
  rpc GetProductById (ProductById) returns (Product) {}
  rpc GetProducts (Void) returns (Products);
  ##//# Void comes from basic.proto
}

```